### PR TITLE
Handle empty string as input

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const stringLength = string => {
 	if (string === '') {
 		return 0;
 	}
-	return stripAnsi(string).match(charRegex()).length
+
+	return stripAnsi(string).match(charRegex()).length;
 };
 
 module.exports = stringLength;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 const stripAnsi = require('strip-ansi');
 const charRegex = require('char-regex');
 
-const stringLength = string => stripAnsi(string).match(charRegex()).length;
+const stringLength = string => {
+	if (string === '') {
+		return 0;
+	}
+	return stripAnsi(string).match(charRegex()).length
+};
 
 module.exports = stringLength;

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const test = require('ava');
 const stringLength = require('.');
 
 test('get the real length of a string', t => {
+	t.is(stringLength(''), 0);
 	t.is(stringLength('𠀔'), 1);
 	t.is(stringLength('foo𠁐bar𠀃'), 8);
 	t.is(stringLength('あ'), 1);


### PR DESCRIPTION
Hey @sindresorhus ;-)

I guess it's the first time I'm proposing a PR on one of the many projects you work on and I enjoy using. Thanks again for everything. :clap:

`stringLength('')` fails on empty strings. I think it comes from the recent modification you did with char-regex/astral-regex and the match/replace.

I modified the test and the source just to naïvely fix my problem. Maybe you would fix it another way but if it helps, here's my humble PR ;-)

Thanks