### PR TITLE
Simplify zero-length handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,6 @@
 const stripAnsi = require('strip-ansi');
 const charRegex = require('char-regex');
 
-const stringLength = string => {
-	if (string === '') {
-		return 0;
-	}
-
-	return stripAnsi(string).match(charRegex()).length;
-};
+const stringLength = string => stripAnsi(string).replace(charRegex(), " ").length;
 
 module.exports = stringLength;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 const stripAnsi = require('strip-ansi');
 const charRegex = require('char-regex');
 
-const stringLength = string => stripAnsi(string).replace(charRegex(), " ").length;
+const stringLength = string => stripAnsi(string).replace(charRegex(), ' ').length;
 
 module.exports = stringLength;


### PR DESCRIPTION
In `3.1.0`, the function did `string.replace(regex, " ")`
In `4.0.0`, it was replaced with `string.match(regex)`
In `4.0.1`, a fix was added that emulated `3.1.0`
In this PR, that original replacement logic is reverted back to instead of what made the fix for `4.0.1`

cc @sindresorhus 