### PR TITLE
Correctly handle zero-length ANSI string

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const stripAnsi = require('strip-ansi');
 const charRegex = require('char-regex');
 
 const stringLength = string => {
+	if (string === '') {
+		return 0;
+	}
+
 	const strippedString = stripAnsi(string);
 
 	if (strippedString === '') {

--- a/index.js
+++ b/index.js
@@ -3,11 +3,13 @@ const stripAnsi = require('strip-ansi');
 const charRegex = require('char-regex');
 
 const stringLength = string => {
-	if (string === '') {
+	const strippedString = stripAnsi(string);
+
+	if (strippedString === '') {
 		return 0;
 	}
 
-	return stripAnsi(string).match(charRegex()).length;
+	return strippedString.match(charRegex()).length;
 };
 
 module.exports = stringLength;

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const stringLength = require('.');
 
 test('get the real length of a string', t => {
 	t.is(stringLength(''), 0);
+	t.is(stringLength('\u001B[1m\u001B[22m'), 0);
 	t.is(stringLength('𠀔'), 1);
 	t.is(stringLength('foo𠁐bar𠀃'), 8);
 	t.is(stringLength('あ'), 1);


### PR DESCRIPTION
Currently, counting length of strings with only ansi escape codes will throw an error:
 
```js
stringLength('\u001B[1m\u001B[22m');

// TypeError: Cannot read property 'length' of null
```

This PR fixes that by checking the length of the stripped string first.

The fix is quite straightforward. Alternatively, we can change it to something like `(stripAnsi(string).match(charRegex()) || '').length` (or millions of other ways).