### PR TITLE
Handle zero-width spaces correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default function stringLength(string, {countAnsiEscapeCodes = false} = {}
 		}
 	}
 
-	string = string.replace(/\u200b/g, '');
+	string = string.replace(/\u200B/g, '');
 
 	let length = 0;
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ export default function stringLength(string, {countAnsiEscapeCodes = false} = {}
 		}
 	}
 
+	string = string.replace(/\u200b/g, '');
+
 	let length = 0;
 
 	for (const _ of segmenter.segment(string)) { // eslint-disable-line no-unused-vars


### PR DESCRIPTION
[Zero width spaces](https://en.wikipedia.org/wiki/Zero-width_space) are currently counted as 1 character, despite not being displayed as 1, even in monospace fonts.