### PR TITLE
Replace strip-ansi with native stripVTControlCharacters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 
 const segmenter = new Intl.Segmenter();
 
@@ -8,7 +8,7 @@ export default function stringLength(string, {countAnsiEscapeCodes = false} = {}
 	}
 
 	if (!countAnsiEscapeCodes) {
-		string = stripAnsi(string);
+		string = stripVTControlCharacters(string);
 
 		if (string === '') {
 			return 0;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=16"
+		"node": ">=16.11"
 	},
 	"type": "module",
 	"exports": "./index.js",
@@ -36,9 +36,6 @@
 		"escape",
 		"codes"
 	],
-	"dependencies": {
-		"strip-ansi": "^7.1.0"
-	},
 	"devDependencies": {
 		"ava": "^5.3.0",
 		"tsd": "^0.28.1",


### PR DESCRIPTION
This removes the `strip-ansi` dependency in favor of Node.js's built-in `util.stripVTControlCharacters()`, available since Node 16.11.

The engine requirement is bumped from `>=16` to `>=16.11` to match.

This aligns with the e18e ecosystem cleanup effort and reduces the dependency tree for the 50+ packages that depend on `string-length`.